### PR TITLE
[COMMON] 프로필 이미지 업데이트 로직 변경

### DIFF
--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -36,7 +36,6 @@ export class UserService {
     fs.writeFile(imagePath, image.buffer, function (err) {
       if (err) return { success: false, data: err };
     });
-    //'./uploads/' + user.intra_id + timeVal.toString() + '.png';
     const findPath = user.intra_id + timeVal.toString() + '.png';
     await this.userRepository.updateProfileImage(found.id, findPath);
     found = await this.findUser(user.intra_id);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -27,11 +27,17 @@ export class UserService {
 
   async updateProfileImage(user: UserSessionDto, image: Express.Multer.File) {
     let found = await this.findUser(user.intra_id);
-    const imagePath = './uploads/' + user.intra_id + '.png';
+    if (found.profile) {
+      fs.unlinkSync('./uploads/' + found.profile);
+    }
+    const timeVal = new Date().getTime();
+    const imagePath =
+      './uploads/' + user.intra_id + timeVal.toString() + '.png';
     fs.writeFile(imagePath, image.buffer, function (err) {
       if (err) return { success: false, data: err };
     });
-    const findPath = user.intra_id + '.png';
+    //'./uploads/' + user.intra_id + timeVal.toString() + '.png';
+    const findPath = user.intra_id + timeVal.toString() + '.png';
     await this.userRepository.updateProfileImage(found.id, findPath);
     found = await this.findUser(user.intra_id);
     return { success: true, data: found };

--- a/frontend/src/api/atom.ts
+++ b/frontend/src/api/atom.ts
@@ -1,4 +1,4 @@
-import { atom, selector } from "recoil";
+import { atom, DefaultValue, selector } from "recoil";
 import { Socket } from "socket.io-client";
 import {
   IChatLog,
@@ -21,6 +21,15 @@ export const myInfoState = atom<UserDto>({
     rank_win: 17,
     rank_lose: 2,
   },
+});
+
+export const myIntroduceState = selector<string>({
+  key: "myIntroduceState",
+  get: ({ get }) => get(myInfoState).introduce,
+  set: ({ get, set }, text) =>
+    text instanceof DefaultValue
+      ? set(myInfoState, { ...get(myInfoState) })
+      : set(myInfoState, { ...get(myInfoState), introduce: text }),
 });
 
 export const myNameState = selector({

--- a/frontend/src/api/interface.ts
+++ b/frontend/src/api/interface.ts
@@ -88,14 +88,11 @@ export interface ISelectedGameRecord {
 }
 
 export interface IFriendDto {
-  id: number;
   intra_id: string;
-  introduce: string;
-  join_type: number;
-  normal_lose: number;
-  normal_win: number;
   profile: string;
-  rank_lose: number;
-  rank_win: number;
-  user_id: number;
+}
+
+export interface IFriendRequest {
+  send: IFriendDto;
+  receive: IFriendDto;
 }

--- a/frontend/src/components/Modals/SettingModal/SettingProfile.tsx
+++ b/frontend/src/components/Modals/SettingModal/SettingProfile.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import React, { useEffect, useMemo, useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import { alertModalState, myInfoState } from "../../../api/atom";
 import { axiosUpdateProfileImage } from "../../../api/request";
@@ -6,6 +7,9 @@ import { axiosUpdateProfileImage } from "../../../api/request";
 const SettingProfile = () => {
   const setAlertModal = useSetRecoilState(alertModalState);
   const [myInfo, setMyInfo] = useRecoilState(myInfoState);
+  const [profileImage, setProfileImage] = useState("");
+
+  console.log(myInfo);
   const handleFileUpload = async (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -37,6 +41,7 @@ const SettingProfile = () => {
       });
     }
   };
+
   return (
     <ProfileContainer>
       <Profile image={myInfo.profile} />
@@ -62,12 +67,11 @@ const ProfileContainer = styled.div`
 const Profile = styled.div<{ image: string }>`
   width: 150px;
   height: 150px;
-  background: ${({ image }) =>
-    image
-      ? `url('http://localhost:3000/${image}?v=${new Date().getTime()}')`
-      : 'url("/src/assets/defaultProfile.png")'};
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: center;
   border-radius: 10px;
+  background-size: 100% 100%;
+  background-image: ${({ image }) => `url(http://localhost:3000/${image})`};
 `;
 
 const ModifyButton = styled.label`

--- a/frontend/src/components/Modals/SettingModal/SettingTextarea.tsx
+++ b/frontend/src/components/Modals/SettingModal/SettingTextarea.tsx
@@ -1,13 +1,18 @@
 import styled from "@emotion/styled";
 import { useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
-import { alertModalState, myInfoState } from "../../../api/atom";
+import {
+  alertModalState,
+  myInfoState,
+  myIntroduceState,
+} from "../../../api/atom";
 import { axiosUpdateIntroduce } from "../../../api/request";
 
 const SettingTextArea = () => {
   const [editMode, toggleEdit] = useState(false);
   const [text, setText] = useState("");
-  const [myInfo, setMyInfo] = useRecoilState(myInfoState);
+  //const [myInfo, setMyInfo] = useRecoilState(myInfoState);
+  const [myIntroduce, setMyIntroduce] = useRecoilState(myIntroduceState);
   const setAlertModal = useSetRecoilState(alertModalState);
   const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(e.currentTarget.value);
@@ -15,9 +20,12 @@ const SettingTextArea = () => {
   const msg = "안녕하세요 잘부탁드립니다";
 
   const handleEditIntroduce = async () => {
+    if (!text) return;
     try {
       const result = await axiosUpdateIntroduce(text);
-      setMyInfo({ ...result });
+      setMyIntroduce(text);
+
+      //console.log(myInfo);
 
       //myInfoState 수정 로직 필요
     } catch (e) {
@@ -47,12 +55,12 @@ const SettingTextArea = () => {
       </Header>
       {editMode ? (
         <TextArea
-          placeholder={myInfo.introduce || msg}
+          placeholder={myIntroduce || msg}
           value={text}
           onChange={onChange}
         />
       ) : (
-        <TextDiv>{myInfo.introduce || msg}</TextDiv>
+        <TextDiv>{myIntroduce || msg}</TextDiv>
       )}
     </>
   );

--- a/frontend/src/components/SideMenu/Alarms.tsx
+++ b/frontend/src/components/SideMenu/Alarms.tsx
@@ -1,4 +1,7 @@
 import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { IFriendRequest } from "../../api/interface";
+import { axiosGetFriendRequestList } from "../../api/request";
 
 function convertDate(date: Date) {
   const now = new Date();
@@ -27,6 +30,17 @@ function convertDate(date: Date) {
 
 const Alarm = ({ w }: { w: number }) => {
   const data = createDummyData();
+  //const [data, setData] = useState<IFriendRequest[]>([]);
+
+  useEffect(() => {
+    getRequestList();
+
+    async function getRequestList() {
+      const result = await axiosGetFriendRequestList();
+      //setData([...dat])
+      console.log(result);
+    }
+  }, []);
   return (
     <AlarmContainer w={w}>
       <Background />

--- a/frontend/src/components/SideMenu/SideMenu.tsx
+++ b/frontend/src/components/SideMenu/SideMenu.tsx
@@ -8,6 +8,11 @@ const SideMenu = ({ w }:{ w: number}) => {
     friends: false,
     alarm: false,
   });
+
+  const clickLogout = () => {
+    
+  }
+
   return (
     <SideMenuContainer >
       <FriendsIcon

--- a/frontend/src/pages/HistoryPage/DetailProfile.tsx
+++ b/frontend/src/pages/HistoryPage/DetailProfile.tsx
@@ -40,8 +40,9 @@ const DetailProfile = ({
 };
 
 function getWinRate(win: number, lose: number) {
+  if (win + lose === 0) return "-";
   const result = (win / (win + lose)) * 100;
-  return result.toFixed(1);
+  return result.toFixed(1) + "%";
 }
 
 const Container = styled.div`
@@ -59,7 +60,7 @@ const Container = styled.div`
 const Text = styled.div`
   width: 80%;
   & > div {
-    padding-left: 10px;
+    padding-left: 5px;
   }
   & > .head {
     padding-left: 0;
@@ -77,7 +78,7 @@ const Image = styled.div<{ src: string }>`
       ? `url('http://localhost:3000/${src}?v=${new Date().getTime()}')`
       : 'url("/src/assets/defaultProfile.png")'};
   width: 100%;
-  padding-bottom: 100%; 
+  padding-bottom: 100%;
   background-size: 100% 100%;
   border-radius: 10px;
 `;

--- a/frontend/src/pages/HistoryPage/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage/HistoryPage.tsx
@@ -5,6 +5,7 @@ import { selectedGameRecord } from "../../api/atom";
 import { IGameHistory } from "../../api/interface";
 import { axiosGetHistory } from "../../api/request";
 import useInitHook from "../../api/useInitHook";
+import SideMenu from "../../components/SideMenu/SideMenu";
 import GameDetailInfo from "./GameDetailInfo";
 import Records from "./Records";
 
@@ -58,17 +59,12 @@ const HistoryPage = () => {
         <Records data={list} />
       </GameContainer>
       <SubContainer>
-        <Empty />
+        <SideMenu w={300} />
         <GameDetailInfo />
       </SubContainer>
     </HistoryPageContainer>
   );
 };
-
-const Empty = styled.div`
-  width: 100%;
-  height: 100px;
-`;
 
 const HistoryPageContainer = styled.div`
   height: 95%;

--- a/frontend/src/pages/HistoryPage/Record.tsx
+++ b/frontend/src/pages/HistoryPage/Record.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { selectedGameRecord } from "../../api/atom";
 import { axiosGetUserGameRecord } from "../../api/request";
 
@@ -36,9 +36,11 @@ const Record = ({
   loser: string;
   time: string;
 }) => {
-  const setSelectedGameRecord = useSetRecoilState(selectedGameRecord);
+  const [selectedGameRcord, setSelectedGameRecord] =
+    useRecoilState(selectedGameRecord);
   const clickRecord = async () => {
     const data = await axiosGetUserGameRecord(id);
+    if (selectedGameRcord.record.id === data.record.id) return;
     setSelectedGameRecord(data);
   };
   return (


### PR DESCRIPTION
### 프로필 이미지 저장 로직
* 기존 `아이디.png` -> `아이디 + unixTimeValue + .png` 로 고유하게 저장
* api에서 user정보를 탐색했을 때 profile 컬럼에 값이 존재하면 기존 파일 삭제
* 비동기 함수 `unlink` 대신 삭제 완료 후 이후 코드를 실행하는 `unlinkSync`를 사용  

### 바꾼 이유
* 프론트 코드에서 `아이디.png`로 요청하는 방식을 사용하면 브라우저에서 파일명을 캐싱하기 때문에 뒤에 임시방편으로 쿼리스트링에 임의의 값을 넣어주었는데 이런 방식으로 요청하게 되면 프로필 이미지를 항상 요청하게 돼서 불필요한 요청을 하는 경우가 생김
* 프로필 이미지가 바뀔 때만 새로 캐싱하기 위해 변경함